### PR TITLE
Use an invisible proxy activity to request permissions

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,6 +11,11 @@ android {
         version = '0.2.0'
         group = 'com.tbruyelle.rxpermissions'
     }
+
+    sourceSets {
+        main.res.srcDirs 'res', 'res-public'
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -18,8 +23,11 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
     testOptions.unitTests.all {
-        // unitTests.returnDefaultValues = true
         // Always show the result of every unit test, even if it passes.
         testLogging {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,2 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.tbruyelle.rxpermissions" />
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.tbruyelle.rxpermissions"
+    >
+
+  <application>
+    <activity
+        android:name=".ProxyRequestPermissionsActivity"
+        android:theme="@style/NoDisplay"
+        />
+  </application>
+
+</manifest>

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/ProxyRequestPermissionsActivity.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/ProxyRequestPermissionsActivity.java
@@ -1,0 +1,58 @@
+package com.tbruyelle.rxpermissions;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+@TargetApi(Build.VERSION_CODES.M)
+public final class ProxyRequestPermissionsActivity extends Activity {
+
+    private static final String INTENT_PREFIX = BuildConfig.APPLICATION_ID + ".";
+    private static final String INTENT_EXTRA_PREFIX = INTENT_PREFIX + "extra.";
+    private static final String INTENT_BROADCAST_PREFIX = INTENT_PREFIX + ".broadcast";
+
+    public static final String EXTRA_REQ_CODE = INTENT_EXTRA_PREFIX + "REQ_CODE";
+    public static final String EXTRA_PERMISSIONS = INTENT_EXTRA_PREFIX + "PERMISSIONS";
+    public static final String EXTRA_GRANT_RESULTS = INTENT_EXTRA_PREFIX + "GRANT_RESULTS";
+    public static final String ACTION_PERMISSIONS = INTENT_BROADCAST_PREFIX + "PERMISSIONS";
+
+    public static Intent createIntent(Context context, int reqCode, String... permissions) {
+        if (context == null) {
+            throw new NullPointerException("context == null");
+        }
+        if (permissions == null || permissions.length == 0) {
+            throw new IllegalArgumentException("At least one input permission is required");
+        }
+        final Intent intent = new Intent(context, ProxyRequestPermissionsActivity.class);
+        intent.putExtra(EXTRA_REQ_CODE, reqCode);
+        intent.putExtra(EXTRA_PERMISSIONS, permissions);
+        return intent;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Only request permissions once -
+        // permission request result will be delivered to the newly created activity.
+        if (savedInstanceState == null) {
+            final String[] permissions = getIntent().getStringArrayExtra(EXTRA_PERMISSIONS);
+            if (permissions != null && permissions.length > 0) {
+                requestPermissions(permissions, getIntent().getIntExtra(EXTRA_REQ_CODE, 0));
+            }
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions,
+                                           int[] grantResults) {
+        final Intent intent = new Intent(ACTION_PERMISSIONS);
+        intent.putExtra(EXTRA_REQ_CODE, requestCode);
+        intent.putExtra(EXTRA_PERMISSIONS, permissions);
+        intent.putExtra(EXTRA_GRANT_RESULTS, grantResults);
+        sendBroadcast(intent);
+        finish();
+    }
+}

--- a/lib/src/main/res-public/values/public.xml
+++ b/lib/src/main/res-public/values/public.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- No exported public values -->
+</resources>

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="NoDisplay">
+    <item name="android:windowIsTranslucent">true</item>
+    <item name="android:windowBackground">@android:color/transparent</item>
+    <item name="android:windowContentOverlay">@null</item>
+    <item name="android:windowNoTitle">true</item>
+    <item name="android:windowIsFloating">true</item>
+    <item name="android:backgroundDimEnabled">false</item>
+  </style>
+</resources>

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -16,7 +16,8 @@ package com.tbruyelle.rxpermissions;
 
 import android.Manifest;
 import android.annotation.TargetApi;
-import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
@@ -31,14 +32,15 @@ import static org.mockito.Mockito.*;
 
 public class RxPermissionsTest {
 
-    @Mock Activity mActivity;
+    @Mock Context mContext;
 
     RxPermissions mRxPermissions;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mRxPermissions = spy(new RxPermissions(mActivity));
+        when(mContext.getApplicationContext()).thenReturn(mContext);
+        mRxPermissions = spy(new RxPermissions(mContext));
     }
 
     @Test
@@ -104,9 +106,9 @@ public class RxPermissionsTest {
 
         mRxPermissions.request(permission).subscribe(sub1);
         mRxPermissions.request(permission).subscribe(sub2);
-        mRxPermissions.onRequestPermissionsResult(id, new String[]{permission}, result);
+        mRxPermissions.onRequestPermissionsResult(id, new String[] { permission }, result);
 
-        verify(mActivity).requestPermissions(any(String[].class), anyInt());
+        verify(mContext).startActivity(any(Intent.class));
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
@@ -165,7 +167,7 @@ public class RxPermissionsTest {
         mRxPermissions.request(permissions).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(id, permissions, result);
 
-        verify(mActivity).requestPermissions(any(String[].class), anyInt());
+        verify(mContext).startActivity(any(Intent.class));
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
@@ -188,7 +190,7 @@ public class RxPermissionsTest {
         mRxPermissions.request(Manifest.permission.CAMERA).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(id, permissions, result);
 
-        verify(mActivity).requestPermissions(any(String[].class), anyInt());
+        verify(mContext).startActivity(any(Intent.class));
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
@@ -210,9 +212,10 @@ public class RxPermissionsTest {
         mRxPermissions.request(Manifest.permission.CAMERA).subscribe(sub1);
         mRxPermissions.request(permissions).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(id, new String[]{Manifest.permission.READ_PHONE_STATE}, result);
-        mRxPermissions.onRequestPermissionsResult(id, new String[]{Manifest.permission.CAMERA}, result);
+        mRxPermissions.onRequestPermissionsResult(id, new String[] { Manifest.permission.CAMERA },
+                                                  result);
 
-        verify(mActivity, times(2)).requestPermissions(any(String[].class), anyInt());
+        verify(mContext, times(2)).startActivity(any(Intent.class));
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
@@ -235,9 +238,10 @@ public class RxPermissionsTest {
         mRxPermissions.request(Manifest.permission.CAMERA).subscribe(sub1);
         mRxPermissions.request(permissions).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(id, new String[]{Manifest.permission.READ_PHONE_STATE}, resultDenied);
-        mRxPermissions.onRequestPermissionsResult(id, new String[]{Manifest.permission.CAMERA}, resultGranted);
+        mRxPermissions.onRequestPermissionsResult(id, new String[] { Manifest.permission.CAMERA },
+                                                  resultGranted);
 
-        verify(mActivity, times(2)).requestPermissions(any(String[].class), anyInt());
+        verify(mContext, times(2)).startActivity(any(Intent.class));
         sub1.assertNoErrors();
         sub1.assertTerminalEvent();
         sub1.assertUnsubscribed();

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -31,11 +31,6 @@ public class MainActivity extends AppCompatActivity {
         mSurfaceView = (SurfaceView) findViewById(R.id.surfaceView);
     }
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        mRxPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
     public void enableCamera(View v) {
         mRxPermissions.request(Manifest.permission.CAMERA)
                 .subscribe(granted -> {


### PR DESCRIPTION
This allows a consumer to use the library with a regular context and helps to alleviate #3. 

RxPermissions will handle launching an invisible activity which will broadcast permission request result as intent back to the RxPermisssions instance. It's assumed that only one RxPermissions instance will be used at a time - consumer should take care of caching it somewhere.

I am not sure if BroadcastReceiver is the best solution here - I am open to suggestions ;]