### PR TITLE
Basic support for shouldShowRequestPermissionRationale

### DIFF
--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -32,7 +32,17 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void enableCamera(View v) {
-        mRxPermissions.request(Manifest.permission.CAMERA)
+        mRxPermissions.shouldShowRequestPermissionRationale(this, Manifest.permission.CAMERA)
+                .flatMap(should -> {
+                    if (should) {
+                        // User already denied the permission, but didn't
+                        // checked "never ask again".
+                        Toast.makeText(MainActivity.this,
+                                "Please please grant this permission !",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                    return mRxPermissions.request(Manifest.permission.CAMERA);
+                })
                 .subscribe(granted -> {
                     if (granted) {
                         releaseCamera();


### PR DESCRIPTION
 Fix #8

It simply adds a new method which returns an observable and handles sdk version.
This observable can be mixed with the request's one, like done in the sample app.