### PR TITLE
Add RequestEach to observe detailed permission answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ If multiple permissions at the same time, the result is combined :
                 });
 ```
 
+You can also observe a detailed result with `requestEach` :
+
+```java
+ RxPermissions.getInstance(this) // this = a Context
+                .requestEach(Manifest.permission.CAMERA,
+                       Manifest.permission.READ_PHONE_STATE)
+                .subscribe(permission -> { // will emit 2 Permission objects
+                    if (permission.granted) {
+                       // `permission.name` is granted !
+                    }
+                });
+```
+
 Look at the `sample` app for more.
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ If multiple permissions at the same time, the result is combined :
 
 ```java
  RxPermissions.getInstance(this) // this = a Context
-                .request(Manifest.permission.CAMERA,
-                       Manifest.permission.READ_PHONE_STATE)
+                .request(Manifest.permission.CAMERA, Manifest.permission.READ_PHONE_STATE)
                 .subscribe(granted -> {
                     if (granted) {
                        // All requested permissions are granted
@@ -37,8 +36,7 @@ You can also observe a detailed result with `requestEach` :
 
 ```java
  RxPermissions.getInstance(this) // this = a Context
-                .requestEach(Manifest.permission.CAMERA,
-                       Manifest.permission.READ_PHONE_STATE)
+                .requestEach(Manifest.permission.CAMERA, Manifest.permission.READ_PHONE_STATE)
                 .subscribe(permission -> { // will emit 2 Permission objects
                     if (permission.granted) {
                        // `permission.name` is granted !

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/Permission.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/Permission.java
@@ -1,0 +1,37 @@
+package com.tbruyelle.rxpermissions;
+
+public class Permission {
+    public final String name;
+    public final boolean granted;
+
+    public Permission(String name, boolean granted) {
+        this.name = name;
+        this.granted = granted;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Permission that = (Permission) o;
+
+        if (granted != that.granted) return false;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (granted ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Permission{" +
+                "name='" + name + '\'' +
+                ", granted=" + granted +
+                '}';
+    }
+}

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import rx.Observable;
-import rx.functions.FuncN;
+import rx.functions.Func1;
 import rx.subjects.PublishSubject;
 
 public class RxPermissions {
@@ -45,18 +45,48 @@ public class RxPermissions {
 
     // Contains all the current permission requests.
     // Once granted or denied, they are removed from it.
-    private Map<String, PublishSubject<Boolean>> mSubjects = new HashMap<>();
+    private Map<String, PublishSubject<Permission>> mSubjects = new HashMap<>();
 
     private RxPermissions() {
 
     }
 
     /**
-     * Register one or several permission requests and returns an observable.
-     * <p/>
+     * Register one or several permission requests and returns an observable that
+     * emits a {@link Permission} for each requested permission.
+     * <p>
      * For SDK &lt; 23, the observable will immediatly emit true, otherwise
      * the user response to that request.
-     * <p/>
+     * <p>
+     * It handles multiple requests to the same permission, in that case the
+     * same observable will be returned.
+     */
+    public Observable<Permission> requestEach(final String... permissions) {
+        if (permissions == null || permissions.length == 0) {
+            throw new IllegalArgumentException("RxPermissions.request requires at least one input permission");
+        }
+        if (isGranted(permissions)) {
+            // Already granted, or not Android M
+            // Map all requested permissions to granted Permission objects.
+            return Observable.from(permissions)
+                    .map(new Func1<String, Permission>() {
+                        @Override
+                        public Permission call(String s) {
+                            return new Permission(s, true);
+                        }
+                    });
+        }
+        return request_(permissions);
+    }
+
+    /**
+     * Register one or several permission requests and returns an observable that
+     * emits an aggregation of the answers. If all  requested permissions were
+     * granted, it emits true, else false.
+     * <p>
+     * For SDK &lt; 23, the observable will immediately emit true, otherwise
+     * the user response to that request.
+     * <p>
      * It handles multiple requests to the same permission, in that case the
      * same observable will be returned.
      */
@@ -68,13 +98,25 @@ public class RxPermissions {
             // Already granted, or not Android M
             return Observable.just(true);
         }
-        return request_(permissions);
+        return request_(permissions)
+                .toList()
+                .map(new Func1<List<Permission>, Boolean>() {
+                    @Override
+                    public Boolean call(List<Permission> permissions) {
+                        for (Permission p : permissions) {
+                            if (!p.granted) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                });
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private Observable<Boolean> request_(final String... permissions) {
+    private Observable<Permission> request_(final String... permissions) {
 
-        List<Observable<Boolean>> list = new ArrayList<>(permissions.length);
+        List<Observable<Permission>> list = new ArrayList<>(permissions.length);
         List<String> unrequestedPermissions = new ArrayList<>();
 
         // In case of multiple permissions, we create a observable for each of them.
@@ -83,7 +125,7 @@ public class RxPermissions {
         // one observable will be create for the CAMERA.
         // At the end, the observables are combined to have a unique response.
         for (String permission : permissions) {
-            PublishSubject<Boolean> subject = mSubjects.get(permission);
+            PublishSubject<Permission> subject = mSubjects.get(permission);
             if (subject == null) {
                 subject = PublishSubject.create();
                 mSubjects.put(permission, subject);
@@ -94,8 +136,7 @@ public class RxPermissions {
         if (!unrequestedPermissions.isEmpty()) {
             startShadowActivity(permissions);
         }
-
-        return Observable.combineLatest(list, combineLatestBools.INSTANCE);
+        return Observable.concat(Observable.from(list));
     }
 
     void startShadowActivity(String[] permissions) {
@@ -107,7 +148,7 @@ public class RxPermissions {
 
     /**
      * Returns true if the permissions is already granted.
-     * <p/>
+     * <p>
      * Always true if SDK &lt; 23.
      */
     public boolean isGranted(String... permissions) {
@@ -124,37 +165,19 @@ public class RxPermissions {
         return true;
     }
 
-    /**
-     * Must be invoked in {@code Activity.onRequestPermissionsResult}
-     * <p/>
-     * The method will find the pending requests and emit the response to the
-     * matching observables.
-     */
     void onRequestPermissionsResult(int requestCode,
                                     String permissions[], int[] grantResults) {
-        for (int i = 0; i < permissions.length; i++) {
+        for (int i = 0, size = permissions.length; i < size; i++) {
             // Find the corresponding subject
-            PublishSubject<Boolean> subject = mSubjects.get(permissions[i]);
+            PublishSubject<Permission> subject = mSubjects.get(permissions[i]);
             if (subject == null) {
                 // No subject found
                 throw new IllegalStateException("RxPermissions.onRequestPermissionsResult invoked but didn't find the corresponding permission request.");
             }
             mSubjects.remove(permissions[i]);
-            subject.onNext(grantResults[i] == PackageManager.PERMISSION_GRANTED);
+            boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
+            subject.onNext(new Permission(permissions[i], granted));
             subject.onCompleted();
-        }
-    }
-
-    private enum combineLatestBools implements FuncN<Boolean> {
-        INSTANCE;
-
-        public Boolean call(Object... args) {
-            for (Object arg : args) {
-                if (!(Boolean) arg) {
-                    return false;
-                }
-            }
-            return true;
         }
     }
 }

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -20,14 +20,24 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 
-import org.junit.*;
-import org.mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 import rx.observers.TestSubscriber;
 
-import static org.mockito.Mockito.*;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RxPermissionsTest {
 
@@ -45,6 +55,21 @@ public class RxPermissionsTest {
 
     @Test
     @TargetApi(Build.VERSION_CODES.M)
+    public void singleSubscription_preM() {
+        TestSubscriber<Boolean> sub = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(true);
+
+        mRxPermissions.request(permission).subscribe(sub);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        sub.assertReceivedOnNext(singletonList(true));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
     public void singleSubscription_granted() {
         TestSubscriber<Boolean> sub = new TestSubscriber<>();
         String permission = Manifest.permission.READ_PHONE_STATE;
@@ -57,7 +82,39 @@ public class RxPermissionsTest {
         sub.assertNoErrors();
         sub.assertTerminalEvent();
         sub.assertUnsubscribed();
-        sub.assertReceivedOnNext(Collections.singletonList(true));
+        sub.assertReceivedOnNext(singletonList(true));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void singleEachSubscription_granted() {
+        TestSubscriber<Permission> sub = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(permission).subscribe(sub);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        sub.assertReceivedOnNext(singletonList(new Permission(permission, true)));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void singleEachSubscription_preM() {
+        TestSubscriber<Permission> sub = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(true);
+
+        mRxPermissions.requestEach(permission).subscribe(sub);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        sub.assertReceivedOnNext(singletonList(new Permission(permission, true)));
     }
 
     @Test
@@ -72,7 +129,7 @@ public class RxPermissionsTest {
         sub.assertNoErrors();
         sub.assertTerminalEvent();
         sub.assertUnsubscribed();
-        sub.assertReceivedOnNext(Collections.singletonList(true));
+        sub.assertReceivedOnNext(singletonList(true));
     }
 
     @Test
@@ -89,7 +146,24 @@ public class RxPermissionsTest {
         sub.assertNoErrors();
         sub.assertTerminalEvent();
         sub.assertUnsubscribed();
-        sub.assertReceivedOnNext(Collections.singletonList(false));
+        sub.assertReceivedOnNext(singletonList(false));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void singleEachSubscription_denied() {
+        TestSubscriber<Permission> sub = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_DENIED};
+
+        mRxPermissions.requestEach(permission).subscribe(sub);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        sub.assertReceivedOnNext(singletonList(new Permission(permission, false)));
     }
 
     @Test
@@ -110,8 +184,53 @@ public class RxPermissionsTest {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
             sub.assertUnsubscribed();
-            sub.assertReceivedOnNext(Collections.singletonList(true));
+            sub.assertReceivedOnNext(singletonList(true));
         }
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalEachSubscription() {
+        TestSubscriber<Permission> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(permission).subscribe(sub1);
+        mRxPermissions.requestEach(permission).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
+
+        verify(mRxPermissions).startShadowActivity(any(String[].class));
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
+            sub.assertNoErrors();
+            sub.assertTerminalEvent();
+            sub.assertUnsubscribed();
+            sub.assertReceivedOnNext(singletonList(new Permission(permission, true)));
+        }
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalMixedSubscription() {
+        TestSubscriber<Boolean> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String permission = Manifest.permission.READ_PHONE_STATE;
+        when(mRxPermissions.isGranted(permission)).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.request(permission).subscribe(sub1);
+        mRxPermissions.requestEach(permission).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
+
+        verify(mRxPermissions).startShadowActivity(any(String[].class));
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
+            sub.assertNoErrors();
+            sub.assertTerminalEvent();
+            sub.assertUnsubscribed();
+        }
+        sub1.assertReceivedOnNext(singletonList(true));
+        sub2.assertReceivedOnNext(singletonList(new Permission(permission, true)));
     }
 
     @Test
@@ -128,7 +247,27 @@ public class RxPermissionsTest {
         sub.assertNoErrors();
         sub.assertTerminalEvent();
         sub.assertUnsubscribed();
-        sub.assertReceivedOnNext(Collections.singletonList(true));
+        sub.assertReceivedOnNext(singletonList(true));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void singleEachSubscription_severalPermissions_granted() {
+        TestSubscriber<Permission> sub = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(permissions).subscribe(sub);
+        mRxPermissions.onRequestPermissionsResult(0, permissions, result);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        List<Permission> ps = new ArrayList<>();
+        ps.add(new Permission(permissions[0], true));
+        ps.add(new Permission(permissions[1], true));
+        sub.assertReceivedOnNext(ps);
     }
 
     @Test
@@ -145,7 +284,27 @@ public class RxPermissionsTest {
         sub.assertNoErrors();
         sub.assertTerminalEvent();
         sub.assertUnsubscribed();
-        sub.assertReceivedOnNext(Collections.singletonList(false));
+        sub.assertReceivedOnNext(singletonList(false));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void singleEachSubscription_severalPermissions_oneDenied() {
+        TestSubscriber<Permission> sub = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED};
+
+        mRxPermissions.requestEach(permissions).subscribe(sub);
+        mRxPermissions.onRequestPermissionsResult(0, permissions, result);
+
+        sub.assertNoErrors();
+        sub.assertTerminalEvent();
+        sub.assertUnsubscribed();
+        List<Permission> ps = new ArrayList<>();
+        ps.add(new Permission(permissions[0], true));
+        ps.add(new Permission(permissions[1], false));
+        sub.assertReceivedOnNext(ps);
     }
 
     @Test
@@ -166,7 +325,32 @@ public class RxPermissionsTest {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
             sub.assertUnsubscribed();
-            sub.assertReceivedOnNext(Collections.singletonList(true));
+            sub.assertReceivedOnNext(singletonList(true));
+        }
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalEachSubscription_severalSamePermissions() {
+        TestSubscriber<Permission> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(permissions).subscribe(sub1);
+        mRxPermissions.requestEach(permissions).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, permissions, result);
+
+        verify(mRxPermissions).startShadowActivity(any(String[].class));
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
+            sub.assertNoErrors();
+            sub.assertTerminalEvent();
+            sub.assertUnsubscribed();
+            List<Permission> ps = new ArrayList<>();
+            ps.add(new Permission(permissions[0], true));
+            ps.add(new Permission(permissions[1], true));
+            sub.assertReceivedOnNext(ps);
         }
     }
 
@@ -188,8 +372,34 @@ public class RxPermissionsTest {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
             sub.assertUnsubscribed();
-            sub.assertReceivedOnNext(Collections.singletonList(true));
+            sub.assertReceivedOnNext(singletonList(true));
         }
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalEachSubscription_severalMixingPermissions_requestSeveralFirst() {
+        TestSubscriber<Permission> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(permissions).subscribe(sub1);
+        mRxPermissions.requestEach(Manifest.permission.CAMERA).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, permissions, result);
+
+        verify(mRxPermissions).startShadowActivity(any(String[].class));
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
+            sub.assertNoErrors();
+            sub.assertTerminalEvent();
+            sub.assertUnsubscribed();
+        }
+        List<Permission> ps = new ArrayList<>();
+        ps.add(new Permission(permissions[0], true));
+        ps.add(new Permission(permissions[1], true));
+        sub1.assertReceivedOnNext(ps);
+        sub2.assertReceivedOnNext(singletonList(new Permission(permissions[1], true)));
     }
 
     @Test
@@ -211,8 +421,35 @@ public class RxPermissionsTest {
             sub.assertNoErrors();
             sub.assertTerminalEvent();
             sub.assertUnsubscribed();
-            sub.assertReceivedOnNext(Collections.singletonList(true));
+            sub.assertReceivedOnNext(singletonList(true));
         }
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalEachSubscription_severalMixingPermissions_requestOnceFirst() {
+        TestSubscriber<Permission> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
+
+        mRxPermissions.requestEach(Manifest.permission.CAMERA).subscribe(sub1);
+        mRxPermissions.requestEach(permissions).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, result);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, result);
+
+        verify(mRxPermissions, times(2)).startShadowActivity(any(String[].class));
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
+            sub.assertNoErrors();
+            sub.assertTerminalEvent();
+            sub.assertUnsubscribed();
+        }
+        sub1.assertReceivedOnNext(singletonList(new Permission(permissions[1], true)));
+        List<Permission> ps = new ArrayList<>();
+        ps.add(new Permission(permissions[0], true));
+        ps.add(new Permission(permissions[1], true));
+        sub2.assertReceivedOnNext(ps);
     }
 
     @Test
@@ -234,10 +471,39 @@ public class RxPermissionsTest {
         sub1.assertNoErrors();
         sub1.assertTerminalEvent();
         sub1.assertUnsubscribed();
-        sub1.assertReceivedOnNext(Collections.singletonList(true));
+        sub1.assertReceivedOnNext(singletonList(true));
         sub2.assertNoErrors();
         sub2.assertTerminalEvent();
         sub2.assertUnsubscribed();
-        sub2.assertReceivedOnNext(Collections.singletonList(false));
+        sub2.assertReceivedOnNext(singletonList(false));
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void severalEachSubscription_severalMixingPermissions_oneDenied() {
+        TestSubscriber<Permission> sub1 = new TestSubscriber<>();
+        TestSubscriber<Permission> sub2 = new TestSubscriber<>();
+        String[] permissions = new String[]{Manifest.permission.READ_PHONE_STATE, Manifest.permission.CAMERA};
+        when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
+        int[] resultGranted = new int[]{PackageManager.PERMISSION_GRANTED};
+        int[] resultDenied = new int[]{PackageManager.PERMISSION_DENIED};
+
+        mRxPermissions.requestEach(Manifest.permission.CAMERA).subscribe(sub1);
+        mRxPermissions.requestEach(permissions).subscribe(sub2);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, resultDenied);
+        mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, resultGranted);
+
+        verify(mRxPermissions, times(2)).startShadowActivity(any(String[].class));
+        sub1.assertNoErrors();
+        sub1.assertTerminalEvent();
+        sub1.assertUnsubscribed();
+        sub1.assertReceivedOnNext(singletonList(new Permission(permissions[1], true)));
+        sub2.assertNoErrors();
+        sub2.assertTerminalEvent();
+        sub2.assertUnsubscribed();
+        List<Permission> ps = new ArrayList<>();
+        ps.add(new Permission(permissions[0], false));
+        ps.add(new Permission(permissions[1], true));
+        sub2.assertReceivedOnNext(ps);
     }
 }


### PR DESCRIPTION
Fix #5 

This is the implementation suggested by @dadino : 

```java
RxPermissions.getInstance(this) // this = a Context
               .requestEach(Manifest.permission.CAMERA, Manifest.permission.READ_PHONE_STATE)
                .subscribe(permission -> { // will emit 2 Permission objects
                    if (permission.granted) {
                       // `permission.name` is granted !
                    }
                });
```