### PR TITLE
RxJava 1.1.0 compatibility

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -165,7 +165,7 @@ public class RxPermissions {
      */
     private Observable<?> pending(final String... permissions) {
         for (String p : permissions) {
-            Subject s = mSubjects.get(p);
+            PublishSubject s = mSubjects.get(p);
             if (s == null || !s.hasCompleted()) {
                 return Observable.empty();
             }


### PR DESCRIPTION
[RxJava 1.1.0](https://github.com/ReactiveX/RxJava/releases/tag/1.1.0) has removed previously deprecated method Subject.hasCompleted(), which was moved to concrete Subject implementations.