### PR TITLE
Remove onDestroy() callbacks

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -301,6 +301,15 @@ public class RxPermissions {
         return mCtx.getPackageManager().isPermissionRevokedByPolicy(permission, mCtx.getPackageName());
     }
 
+    void onDestroy() {
+        log("onDestroy");
+        // Invoke onCompleted on all registered subjects.
+        // This should un-subscribe the observers.
+        for (Subject subject : mSubjects.values()) {
+            subject.onCompleted();
+        }
+    }
+
     void onRequestPermissionsResult(int requestCode,
                                     String permissions[], int[] grantResults) {
         for (int i = 0, size = permissions.length; i < size; i++) {

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -301,15 +301,6 @@ public class RxPermissions {
         return mCtx.getPackageManager().isPermissionRevokedByPolicy(permission, mCtx.getPackageName());
     }
 
-    void onDestroy() {
-        log("onDestroy");
-        // Invoke onCompleted on all registered subjects.
-        // This should un-subscribe the observers.
-        for (Subject subject : mSubjects.values()) {
-            subject.onCompleted();
-        }
-    }
-
     void onRequestPermissionsResult(int requestCode,
                                     String permissions[], int[] grantResults) {
         for (int i = 0, size = permissions.length; i < size; i++) {

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/ShadowActivity.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/ShadowActivity.java
@@ -28,12 +28,6 @@ public class ShadowActivity extends Activity {
     }
 
     @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        RxPermissions.getInstance(this).onDestroy();
-    }
-
-    @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         RxPermissions.getInstance(this).onRequestPermissionsResult(requestCode, permissions, grantResults);
         finish();


### PR DESCRIPTION
Fixes bug when retrying permission request would only return onComplete() without emiting any item. See Issue #32.