### PR TITLE
Upload to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: android
 android:
   components:
     - tools
+    - platform-tools
     - build-tools-23.0.2
     - android-23
     - extra-android-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }
 
@@ -23,4 +25,25 @@ ext {
     appCompat = 'com.android.support:appcompat-v7:23.0.1'
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'
+
+    bintrayRepo = 'tbruyelle'
+    bintrayName = 'RxPermissions'
+
+    publishedGroupId = 'com.tbruyelle'
+    artifact = 'rxpermissions'
+    libraryName = 'RxPermissions'
+    libraryVersion = '0.5.2'
+
+    libraryDescription = 'A wrapper for Android 6.0 permissions'
+
+    siteUrl = 'https://github.com/tbruyelle/RxPermissions'
+    gitUrl = 'https://github.com/tbruyelle/RxPermissions.git'
+
+    developerId = 'tbruyelle'
+    developerName = 'Thomas Bruyelle'
+    developerEmail = 'thomas.bruyelle@gmail.com'
+
+    licenseName = 'The Apache Software License, Version 2.0'
+    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+    allLicenses = ["Apache-2.0"]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ ext {
     bintrayRepo = 'tbruyelle'
     bintrayName = 'RxPermissions'
 
-    publishedGroupId = 'com.tbruyelle'
+    publishedGroupId = 'com.tbruyelle.rxpermissions'
     artifact = 'rxpermissions'
     libraryName = 'RxPermissions'
     libraryVersion = '0.5.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/lib/bintray.gradle
+++ b/lib/bintray.gradle
@@ -1,0 +1,48 @@
+apply plugin: 'com.jfrog.bintray'
+
+version = libraryVersion
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+
+bintray {
+    user = properties.getProperty("bintray.user")
+    key = properties.getProperty("bintray.apikey")
+
+    configurations = ['archives']
+    pkg {
+        repo = bintrayRepo
+        name = bintrayName
+        desc = libraryDescription
+        websiteUrl = siteUrl
+        vcsUrl = gitUrl
+        licenses = allLicenses
+        publish = true
+        publicDownloadNumbers = true
+        version {
+            desc = libraryDescription
+            gpg {
+                sign = false
+            }
+        }
+    }
+}

--- a/lib/bintray.gradle
+++ b/lib/bintray.gradle
@@ -22,7 +22,9 @@ artifacts {
 }
 
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
+try {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+} catch (FileNotFoundException ignore) {}
 
 bintray {
     user = properties.getProperty("bintray.user")

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -33,3 +33,6 @@ dependencies {
     testCompile rootProject.ext.junit
     testCompile rootProject.ext.mockito
 }
+
+apply from: 'install.gradle'
+apply from: 'bintray.gradle'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,8 +8,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 11
-        version = '0.5.2'
-        group = 'com.tbruyelle.rxpermissions'
+        version = rootProject.ext.libraryVersion
+        group = rootProject.ext.publishedGroupId + rootProject.ext.artifact
     }
     buildTypes {
         release {

--- a/lib/install.gradle
+++ b/lib/install.gradle
@@ -1,0 +1,39 @@
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = publishedGroupId
+
+install {
+    repositories.mavenInstaller {
+        pom {
+            project {
+                packaging 'aar'
+                groupId publishedGroupId
+                artifactId artifact
+
+                name libraryName
+                description libraryDescription
+                url siteUrl
+
+                licenses {
+                    license {
+                        name licenseName
+                        url licenseUrl
+                    }
+                }
+                developers {
+                    developer {
+                        id developerId
+                        name developerName
+                        email developerEmail
+                    }
+                }
+                scm {
+                    connection gitUrl
+                    developerConnection gitUrl
+                    url siteUrl
+
+                }
+            }
+        }
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    compile project(':lib')
+    compile project(':rxpermissions')
 
     compile rootProject.ext.appCompat
     compile 'com.jakewharton.rxbinding:rxbinding:0.2.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,4 @@
-include 'lib'
+include 'rxpermissions'
+project(':rxpermissions').projectDir = new File(settingsDir, '/lib')
+project(':rxpermissions').name = 'rxpermissions'
 include 'sample'


### PR DESCRIPTION
Scripts and configuration to upload to bintray with a valid pom (and be able to link it with jcenter())

it needs 2 properties, bintray.user and bintray.apikey in local.properties.

I had to change the local name of the lib folder when importing in gradle because the script kept exporting 'lib' but I don't think it's an extreme change (it should* exist another way to do it).