### PR TITLE
Change the way configuration changes are handled

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,12 +18,15 @@ android {
         }
     }
 
+    testOptions.unitTests.returnDefaultValues = true
+
     testOptions.unitTests.all {
         // unitTests.returnDefaultValues = true
         // Always show the result of every unit test, even if it passes.
         testLogging {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
+
     }
 }
 

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -47,6 +47,9 @@ public class RxPermissions {
 
     private Context mCtx;
 
+    // Contains all the permission requests, which have no result yet
+    private List<PublishSubject<Permission>> mNoResultSubjects = new ArrayList<>();
+
     // Contains all the current permission requests.
     // Once granted or denied, they are removed from it.
     private Map<String, PublishSubject<Permission>> mSubjects = new HashMap<>();
@@ -166,7 +169,7 @@ public class RxPermissions {
     private Observable<?> pending(final String... permissions) {
         for (String p : permissions) {
             PublishSubject s = mSubjects.get(p);
-            if (s == null || !s.hasCompleted()) {
+            if (s == null || !mNoResultSubjects.contains(s)) {
                 return Observable.empty();
             }
         }
@@ -207,11 +210,12 @@ public class RxPermissions {
             }
 
             PublishSubject<Permission> subject = mSubjects.get(permission);
-            // Create a new subject if not exists OR if completed.
+            // Create a new subject if not exists OR if it did not receive a result.
             // This last case occurs on configuration change, and in that case
             // we need to recreate a new subject, but without request the permission
             // again.
-            if (subject == null || subject.hasCompleted()) {
+            if (subject == null || mNoResultSubjects.contains(subject)) {
+                mNoResultSubjects.remove(subject);
                 if (subject == null) {
                     unrequestedPermissions.add(permission);
                 }
@@ -306,8 +310,8 @@ public class RxPermissions {
      */
     public void onDestroy() {
         log("onDestroy");
-        for (Subject subject : mSubjects.values()) {
-            subject.onCompleted();
+        for (PublishSubject<Permission> subject : mSubjects.values()) {
+            mNoResultSubjects.add(subject);
         }
     }
 

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -635,8 +635,6 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertTerminalEvent();
-            sub.assertUnsubscribed();
             sub.assertNoValues();
         }
 
@@ -669,8 +667,6 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertTerminalEvent();
-            sub.assertUnsubscribed();
             sub.assertNoValues();
         }
 


### PR DESCRIPTION
In `onDestroy()`, `onCompleted()` was called on all subjects for unsubscribing. However, in my opinion, users should unsubscribe their Subscriptions anyway, when their Activity gets destroyed (e.g. with a CompositeSubscription). It is better to have a separate list, which contains all subjects that did not receive a result from permission requests, which I implemented in this pull request.

This way, configuration changes are handled correctly, while also fixing issue #32. 