### PR TITLE
Replace observable methods by composable methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ cache:
   directories:
     - $HOME/.gradle
 
-script: ./gradlew build test
+script: ./gradlew test

--- a/README.md
+++ b/README.md
@@ -7,21 +7,33 @@ This library allows the usage of RxJava with the new Android M permission model.
 Example (With Retrolambda for brevity, but not required):
 
 ```java
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
+// Must be done during an initialization phase like onCreate
+RxPermissions.getInstance(this)
+    .request(Manifest.permission.CAMERA)
+    .subscribe(granted -> {
+        if (granted) { // Always true pre-M
+           // I can control the camera now
+        } else {
+           // Oups permission denied
+        }
+    });
+```
 
-    // Must be done during an initialization phase like onCreate
-    RxPermissions.getInstance(this)
-        .request(Manifest.permission.CAMERA)
-        .subscribe(granted -> {
-            if (granted) { // Always true pre-M
-               // I can control the camera now
-            } else {
-               // Oups permission denied
-            }
-        });
-}
+If you need to trigger the permission request from a specific event, you need to setup your event
+as an observable inside an initialization phase.
+
+You can use [JakeWharton/RxBinding](https://github.com/JakeWharton/RxBinding) to turn your view to
+an observable (not included in the library).
+
+Example :
+
+```java
+// Must be done during an initialization phase like onCreate
+RxView.clicks(findViewById(R.id.enableCamera))
+    .compose(RxPermissions.getInstance(this).ensure(Manifest.permission.CAMERA))
+    .subscribe(granted -> {
+        // R.id.enableCamera has been clicked
+    });
 ```
 
 If multiple permissions at the same time, the result is combined :
@@ -39,11 +51,11 @@ RxPermissions.getInstance(this)
     });
 ```
 
-You can also observe a detailed result with `requestEach` :
+You can also observe a detailed result with `requestEach` or `ensureEach` :
 
 ```java
 RxPermissions.getInstance(this)
-.requestEach(Manifest.permission.CAMERA,
+    .requestEach(Manifest.permission.CAMERA,
              Manifest.permission.READ_PHONE_STATE)
     .subscribe(permission -> { // will emit 2 Permission objects
         if (permission.granted) {
@@ -56,35 +68,18 @@ Look at the `sample` app for more.
 
 ## Important read
 
-**Because your app may be restarted during the permission request, the request must be done 
-during an initialization phase**. This may be `Activity.onCreate/onResume`, or `View.onFinishInflate` or others.
+**As mentioned above, because your app may be restarted during the permission request, the request
+must be done during an initialization phase**. This may be `Activity.onCreate/onResume`, or
+`View.onFinishInflate` or others.
 
-If not, and if your app is restarted during the permission request (because of a configuration change for instance),
-the user's answer will never be emitted to the subscriber.
+If not, and if your app is restarted during the permission request (because of a configuration
+change for instance), the user's answer will never be emitted to the subscriber.
 
-If you need to trigger the permission request from a specific event and not during initialization phase, you have
-to pass an extra parameter to the library methods, the trigger.
-The trigger must be an `Observable`, you can use  [JakeWharton/RxBinding](https://github.com/JakeWharton/RxBinding)
-to turn your view to an observable (not included in the library).
+## Migration to 0.6.x
 
-Example :
-
-```java
-@Override
-protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-
-    Observable<Void> trigger = RxView.clicks(findViewById(R.id.enableCamera));
-
-    RxPermissions.getInstance(this)
-        // The trigger is passed as first arg
-        .request(trigger, Manifest.permission.CAMERA)
-        .subscribe(granted -> {
-            // R.id.enableCamera has been clicked
-        });
-}
-```
-
+Version 0.6.0 replaced the methods `request(trigger, permission...)` and `requestEach(trigger, permission...)`
+by *composables* methods `ensure(permission...)` and `ensureEach(permission...)`. Read the second
+example to see how to use them.
 
 ## Status
 
@@ -93,14 +88,17 @@ I'm currently using it in production since months without issue.
 
 ## Benefits
 
-- Avoid worrying about the framework version. If the sdk is pre-M, the observer will automatically receive a granted result.
+- Avoid worrying about the framework version. If the sdk is pre-M, the observer will automatically
+receive a granted result.
 
 - Prevents you to split your code between the permission request and the result handling.
-Currently without this library you have to request the permission in one place and handle the result in `Activity.onRequestPermissionsResult()`.
+Currently without this library you have to request the permission in one place and handle the result
+in `Activity.onRequestPermissionsResult()`.
 
 - Handles multiple permission requests out of the box.
-For instance if during the initialization of your app you request the same permission in 2 different places, only one request will
-be made to the framework. As a result, only one popup will appear to the user, but his response will be dispatched to all requesters.
+For instance if during the initialization of your app you request the same permission in 2 different
+places, only one request will be made to the framework. As a result, only one popup will appear to
+the user, but his response will be dispatched to all requesters.
 
 - All what RX provides about transformation, filter, chaining...
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     targetSdkVersion = compileSdkVersion
     buildToolsVersion = '23.0.2'
 
-    rxJava = 'io.reactivex:rxjava:1.1.0'
+    rxJava = 'io.reactivex:rxjava:1.1.1'
     appCompat = 'com.android.support:appcompat-v7:23.0.1'
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
     publishedGroupId = 'com.tbruyelle.rxpermissions'
     artifact = 'rxpermissions'
     libraryName = 'RxPermissions'
-    libraryVersion = '0.5.2'
+    libraryVersion = '0.6.0'
 
     libraryDescription = 'A wrapper for Android 6.0 permissions'
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,15 +18,12 @@ android {
         }
     }
 
-    testOptions.unitTests.returnDefaultValues = true
-
     testOptions.unitTests.all {
         // unitTests.returnDefaultValues = true
         // Always show the result of every unit test, even if it passes.
         testLogging {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
-
     }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,12 +18,15 @@ android {
         }
     }
 
+    testOptions.unitTests.returnDefaultValues = true
+
     testOptions.unitTests.all {
         // unitTests.returnDefaultValues = true
         // Always show the result of every unit test, even if it passes.
         testLogging {
             events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
         }
+
     }
 }
 

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -120,6 +120,22 @@ public class RxPermissions {
         };
     }
 
+    /**
+     * Request permissions immediately, <b>must be invoked during initialization phase
+     * of your application</b>.
+     */
+    public Observable<Boolean> request(final String... permissions) {
+        return Observable.just(null).compose(ensure(permissions));
+    }
+
+    /**
+     * Request permissions immediately, <b>must be invoked during initialization phase
+     * of your application</b>.
+     */
+    public Observable<Permission> requestEach(final String... permissions) {
+        return Observable.just(null).compose(ensureEach(permissions));
+    }
+
     private Observable<Permission> request(final Observable<?> trigger,
                                            final String... permissions) {
         if (permissions == null || permissions.length == 0) {
@@ -127,12 +143,12 @@ public class RxPermissions {
         }
         // If there's pending request
         if (pending(permissions)) {
-            return request(permissions);
+            return request_(permissions);
         }
         return trigger.flatMap(new Func1<Object, Observable<Permission>>() {
             @Override
             public Observable<Permission> call(Object o) {
-                return request(permissions);
+                return request_(permissions);
             }
         });
     }
@@ -147,7 +163,7 @@ public class RxPermissions {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private Observable<Permission> request(final String... permissions) {
+    private Observable<Permission> request_(final String... permissions) {
 
         List<Observable<Permission>> list = new ArrayList<>(permissions.length);
         List<String> unrequestedPermissions = new ArrayList<>();

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -75,11 +75,11 @@ public class RxPermissions {
      * If one or several permissions have never been requested, invoke the related framework method
      * to ask the user if he allows the permissions.
      */
-    public static Observable.Transformer<Object, Boolean> ensure(final Context ctx, final String... permissions) {
+    public Observable.Transformer<Object, Boolean> ensure(final String... permissions) {
         return new Observable.Transformer<Object, Boolean>() {
             @Override
             public Observable<Boolean> call(Observable<Object> o) {
-                return RxPermissions.getInstance(ctx).request(o, permissions)
+                return request(o, permissions)
                         // Transform Observable<Permission> to Observable<Boolean>
                         .buffer(permissions.length)
                         .flatMap(new Func1<List<Permission>, Observable<Boolean>>() {
@@ -111,11 +111,11 @@ public class RxPermissions {
      * If one or several permissions have never been requested, invoke the related framework method
      * to ask the user if he allows the permissions.
      */
-    public static Observable.Transformer<Object, Permission> ensureEach(final Context ctx, final String... permissions) {
+    public Observable.Transformer<Object, Permission> ensureEach(final String... permissions) {
         return new Observable.Transformer<Object, Permission>() {
             @Override
             public Observable<Permission> call(Observable<Object> o) {
-                return RxPermissions.getInstance(ctx).request(o, permissions);
+                return request(o, permissions);
             }
         };
     }

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import rx.Observable;
 import rx.functions.Func1;
 import rx.subjects.PublishSubject;
-import rx.subjects.Subject;
 
 public class RxPermissions {
 

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -36,7 +36,7 @@ import rx.subjects.Subject;
 public class RxPermissions {
 
     public static final String TAG = "RxPermissions";
-    private static RxPermissions sSingleton;
+    static RxPermissions sSingleton;
 
     public static RxPermissions getInstance(Context ctx) {
         if (sSingleton == null) {
@@ -88,20 +88,6 @@ public class RxPermissions {
      * Register one or several permission requests and returns an observable that
      * emits a {@link Permission} for each requested permission.
      * <p>
-     * For SDK &lt; 23, the observable will immediately emit true, otherwise
-     * the user response to that request.
-     * <p>
-     * It handles multiple requests to the same permission, in that case the
-     * same observable will be returned.
-     */
-    public Observable<Permission> requestEach(final String... permissions) {
-        return requestEach(null, permissions);
-    }
-
-    /**
-     * Register one or several permission requests and returns an observable that
-     * emits a {@link Permission} for each requested permission.
-     * <p>
      * The request is only executed when the `trigger` observable emits something.
      * <p>
      * For SDK &lt; 23, the observable will immediately emit true, otherwise
@@ -110,8 +96,8 @@ public class RxPermissions {
      * It handles multiple requests to the same permission, in that case the
      * same observable will be returned.
      */
-    public Observable<Permission> requestEach(final Observable<?> trigger,
-                                              final String... permissions) {
+    private Observable<Permission> requestEach(final Observable<?> trigger,
+                                               final String... permissions) {
         if (permissions == null || permissions.length == 0) {
             throw new IllegalArgumentException("RxPermissions.request/requestEach requires at least one input permission");
         }
@@ -124,20 +110,6 @@ public class RxPermissions {
                 });
     }
 
-    /**
-     * Register one or several permission requests and returns an observable that
-     * emits an aggregation of the answers. If all  requested permissions were
-     * granted, it emits true, else false.
-     * <p>
-     * For SDK &lt; 23, the observable will immediately emit true, otherwise
-     * the user response to that request.
-     * <p>
-     * It handles multiple requests to the same permission, in that case the
-     * same observable will be returned.
-     */
-    public Observable<Boolean> request(final String... permissions) {
-        return request(null, permissions);
-    }
 
     /**
      * Register one or several permission requests and returns an observable that
@@ -152,7 +124,7 @@ public class RxPermissions {
      * It handles multiple requests to the same permission, in that case the
      * same observable will be returned.
      */
-    public Observable<Boolean> request(final Observable<?> trigger, final String... permissions) {
+    private Observable<Boolean> request(final Observable<?> trigger, final String... permissions) {
         return requestEach(trigger, permissions)
                 // Transform Observable<Permission> to Observable<Boolean>
                 .buffer(permissions.length)
@@ -200,7 +172,6 @@ public class RxPermissions {
 
     @TargetApi(Build.VERSION_CODES.M)
     private Observable<Permission> request_(final String... permissions) {
-        log("Requesting permissions " + TextUtils.join(", ", permissions));
 
         List<Observable<Permission>> list = new ArrayList<>(permissions.length);
         List<String> unrequestedPermissions = new ArrayList<>();
@@ -211,6 +182,7 @@ public class RxPermissions {
         // one observable will be create for the CAMERA.
         // At the end, the observables are combined to have a unique response.
         for (String permission : permissions) {
+            log("Requesting permission " + permission);
             if (isGranted(permission)) {
                 // Already granted, or not Android M
                 // Return a granted Permission object.

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -68,6 +68,13 @@ public class RxPermissions {
         }
     }
 
+    /**
+     * Map emitted items from the source observable into {@code true} if permissions in parameters
+     * are granted, or {@code false} if not.
+     * <p>
+     * If one or several permissions have never been requested, invoke the related framework method
+     * to ask the user if he allows the permissions.
+     */
     public static Observable.Transformer<Object, Boolean> ensure(final Context ctx, final String... permissions) {
         return new Observable.Transformer<Object, Boolean>() {
             @Override
@@ -77,6 +84,13 @@ public class RxPermissions {
         };
     }
 
+    /**
+     * Map emitted items from the source observable into {@link Permission} objects for each
+     * permissions in parameters.
+     * <p>
+     * If one or several permissions have never been requested, invoke the related framework method
+     * to ask the user if he allows the permissions.
+     */
     public static Observable.Transformer<Object, Permission> ensureEach(final Context ctx, final String... permissions) {
         return new Observable.Transformer<Object, Permission>() {
             @Override
@@ -86,18 +100,6 @@ public class RxPermissions {
         };
     }
 
-    /**
-     * Register one or several permission requests and returns an observable that
-     * emits a {@link Permission} for each requested permission.
-     * <p>
-     * The request is only executed when the `trigger` observable emits something.
-     * <p>
-     * For SDK &lt; 23, the observable will immediately emit true, otherwise
-     * the user response to that request.
-     * <p>
-     * It handles multiple requests to the same permission, in that case the
-     * same observable will be returned.
-     */
     private Observable<Permission> requestEach(final Observable<?> trigger,
                                                final String... permissions) {
         if (permissions == null || permissions.length == 0) {
@@ -114,19 +116,7 @@ public class RxPermissions {
         });
     }
 
-    /**
-     * Register one or several permission requests and returns an observable that
-     * emits an aggregation of the answers. If all  requested permissions were
-     * granted, it emits true, else false.
-     * <p>
-     * The request is only executed when the `trigger` observable emits something.
-     * <p>
-     * For SDK &lt; 23, the observable will immediately emit true, otherwise
-     * the user response to that request.
-     * <p>
-     * It handles multiple requests to the same permission, in that case the
-     * same observable will be returned.
-     */
+
     private Observable<Boolean> request(final Observable<?> trigger, final String... permissions) {
         return requestEach(trigger, permissions)
                 // Transform Observable<Permission> to Observable<Boolean>

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -66,6 +66,24 @@ public class RxPermissions {
         }
     }
 
+    public static Observable.Transformer<Object, Boolean> ensure(final Context ctx, final String... permissions) {
+        return new Observable.Transformer<Object, Boolean>() {
+            @Override
+            public Observable<Boolean> call(Observable<Object> o) {
+                return RxPermissions.getInstance(ctx).request(o, permissions);
+            }
+        };
+    }
+
+    public static Observable.Transformer<Object, Permission> ensureEach(final Context ctx, final String... permissions) {
+        return new Observable.Transformer<Object, Permission>() {
+            @Override
+            public Observable<Permission> call(Observable<Object> o) {
+                return RxPermissions.getInstance(ctx).requestEach(o, permissions);
+            }
+        };
+    }
+
     /**
      * Register one or several permission requests and returns an observable that
      * emits a {@link Permission} for each requested permission.
@@ -281,7 +299,7 @@ public class RxPermissions {
      * <p>
      * Always false if SDK &lt; 23.
      */
-    public boolean  isRevoked(String permission) {
+    public boolean isRevoked(String permission) {
         return isMarshmallow() && isRevoked_(permission);
     }
 

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -730,10 +730,8 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            // TODO should be uncommented
-//            sub.assertTerminalEvent();
-//            sub.assertUnsubscribed();
             sub.assertNoValues();
+            sub.assertNoTerminalEvent();
         }
 
         sub1 = new TestSubscriber<>();
@@ -743,16 +741,11 @@ public class RxPermissionsTest {
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
-        for (TestSubscriber sub : new TestSubscriber[]{sub1}) {
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertNoTerminalEvent();
+            sub.assertCompleted();
             sub.assertReceivedOnNext(singletonList(true));
         }
-        // TODO Previous loop should also check sub2 but a bug prevents the second subscriber
-        // to receive the result.
-        // A solution would be to remove concurrent access code, inform the user to only use
-        // one permission at a time or suggest to use share() on the received observable.
-
     }
 
     @Test
@@ -771,10 +764,8 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            // TODO should be uncommented
-//            sub.assertTerminalEvent();
-//            sub.assertUnsubscribed();
             sub.assertNoValues();
+            sub.assertNoTerminalEvent();
         }
 
         sub1 = new TestSubscriber<>();
@@ -784,15 +775,11 @@ public class RxPermissionsTest {
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
-        for (TestSubscriber sub : new TestSubscriber[]{sub1}) {
+        for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertNoTerminalEvent();
+            sub.assertCompleted();
             sub.assertReceivedOnNext(singletonList(new Permission(permission, true)));
         }
-        // TODO Previous loop should also check sub2 but a bug prevents the second subscriber
-        // to receive the result.
-        // A solution would be to remove concurrent access code, inform the user to only use
-        // one permission at a time or suggest to use share() on the received observable.
     }
 
     @Test

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -628,8 +628,6 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertTerminalEvent();
-            sub.assertUnsubscribed();
             sub.assertNoValues();
         }
 
@@ -662,8 +660,6 @@ public class RxPermissionsTest {
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
-            sub.assertTerminalEvent();
-            sub.assertUnsubscribed();
             sub.assertNoValues();
         }
 

--- a/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions/RxPermissionsTest.java
@@ -70,7 +70,7 @@ public class RxPermissionsTest {
         String permission = Manifest.permission.READ_PHONE_STATE;
         when(mRxPermissions.isGranted(permission)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub);
 
         sub.assertNoErrors();
         sub.assertTerminalEvent();
@@ -86,7 +86,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         sub.assertNoErrors();
@@ -103,7 +103,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         sub.assertNoErrors();
@@ -119,7 +119,7 @@ public class RxPermissionsTest {
         String permission = Manifest.permission.READ_PHONE_STATE;
         when(mRxPermissions.isGranted(permission)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub);
 
         sub.assertNoErrors();
         sub.assertTerminalEvent();
@@ -134,7 +134,7 @@ public class RxPermissionsTest {
         String permission = Manifest.permission.READ_PHONE_STATE;
         when(mRxPermissions.isGranted(permission)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub);
 
         sub.assertNoErrors();
         sub.assertTerminalEvent();
@@ -150,7 +150,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         sub.assertNoErrors();
@@ -167,7 +167,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         sub.assertNoErrors();
@@ -183,7 +183,7 @@ public class RxPermissionsTest {
         String permission = Manifest.permission.READ_PHONE_STATE;
         when(mRxPermissions.isRevoked(permission)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub);
 
         sub.assertNoErrors();
         sub.assertTerminalEvent();
@@ -198,7 +198,7 @@ public class RxPermissionsTest {
         String permission = Manifest.permission.READ_PHONE_STATE;
         when(mRxPermissions.isRevoked(permission)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub);
 
         sub.assertNoErrors();
         sub.assertTerminalEvent();
@@ -215,8 +215,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -237,8 +237,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -259,8 +259,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -281,7 +281,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         sub.assertNoErrors();
@@ -298,7 +298,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         sub.assertNoErrors();
@@ -318,7 +318,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         sub.assertNoErrors();
@@ -335,7 +335,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         when(mRxPermissions.isRevoked(Manifest.permission.CAMERA)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0,
                 new String[]{Manifest.permission.READ_PHONE_STATE},
                 new int[]{PackageManager.PERMISSION_GRANTED});
@@ -354,7 +354,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         when(mRxPermissions.isGranted(Manifest.permission.CAMERA)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0,
                 new String[]{Manifest.permission.READ_PHONE_STATE},
                 new int[]{PackageManager.PERMISSION_GRANTED});
@@ -380,7 +380,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         sub.assertNoErrors();
@@ -400,7 +400,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         when(mRxPermissions.isRevoked(Manifest.permission.CAMERA)).thenReturn(true);
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub);
         mRxPermissions.onRequestPermissionsResult(0,
                 new String[]{Manifest.permission.READ_PHONE_STATE},
                 new int[]{PackageManager.PERMISSION_GRANTED});
@@ -423,8 +423,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -445,8 +445,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -470,8 +470,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, Manifest.permission.CAMERA)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(Manifest.permission.CAMERA)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -492,8 +492,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED, PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, Manifest.permission.CAMERA)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(Manifest.permission.CAMERA)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, permissions, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -518,8 +518,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, Manifest.permission.CAMERA)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(Manifest.permission.CAMERA)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, result);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, result);
 
@@ -541,8 +541,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(Matchers.<String>anyVararg())).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, Manifest.permission.CAMERA)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(Manifest.permission.CAMERA)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, result);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, result);
 
@@ -569,8 +569,8 @@ public class RxPermissionsTest {
         int[] resultGranted = new int[]{PackageManager.PERMISSION_GRANTED};
         int[] resultDenied = new int[]{PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, Manifest.permission.CAMERA)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(Manifest.permission.CAMERA)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, resultDenied);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, resultGranted);
 
@@ -595,8 +595,8 @@ public class RxPermissionsTest {
         int[] resultGranted = new int[]{PackageManager.PERMISSION_GRANTED};
         int[] resultDenied = new int[]{PackageManager.PERMISSION_DENIED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, Manifest.permission.CAMERA)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permissions)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(Manifest.permission.CAMERA)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permissions)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.READ_PHONE_STATE}, resultDenied);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{Manifest.permission.CAMERA}, resultGranted);
 
@@ -623,8 +623,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub2);
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
@@ -633,8 +633,8 @@ public class RxPermissionsTest {
 
         sub1 = new TestSubscriber<>();
         sub2 = new TestSubscriber<>();
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensure(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -655,8 +655,8 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted(permission)).thenReturn(false);
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
 
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
             sub.assertNoErrors();
@@ -665,8 +665,8 @@ public class RxPermissionsTest {
 
         sub1 = new TestSubscriber<>();
         sub2 = new TestSubscriber<>();
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub1);
-        trigger().compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub1);
+        trigger().compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -687,7 +687,7 @@ public class RxPermissionsTest {
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
         PublishSubject<Object> trigger = PublishSubject.create();
 
-        trigger.compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub);
+        trigger.compose(mRxPermissions.ensure(permission)).subscribe(sub);
         trigger.onNext(null);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
@@ -705,7 +705,7 @@ public class RxPermissionsTest {
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
         PublishSubject<Object> trigger = PublishSubject.create();
 
-        trigger.compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub);
+        trigger.compose(mRxPermissions.ensureEach(permission)).subscribe(sub);
         trigger.onNext(null);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
@@ -724,8 +724,8 @@ public class RxPermissionsTest {
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
         PublishSubject<Object> trigger = PublishSubject.create();
 
-        trigger.compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger.compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub2);
+        trigger.compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger.compose(mRxPermissions.ensure(permission)).subscribe(sub2);
         trigger.onNext(null);
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
@@ -736,8 +736,8 @@ public class RxPermissionsTest {
 
         sub1 = new TestSubscriber<>();
         sub2 = new TestSubscriber<>();
-        trigger.compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub1);
-        trigger.compose(RxPermissions.ensure(mCtx, permission)).subscribe(sub2);
+        trigger.compose(mRxPermissions.ensure(permission)).subscribe(sub1);
+        trigger.compose(mRxPermissions.ensure(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));
@@ -758,8 +758,8 @@ public class RxPermissionsTest {
         int[] result = new int[]{PackageManager.PERMISSION_GRANTED};
         PublishSubject<Object> trigger = PublishSubject.create();
 
-        trigger.compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub1);
-        trigger.compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger.compose(mRxPermissions.ensureEach(permission)).subscribe(sub1);
+        trigger.compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         trigger.onNext(null);
         mRxPermissions.onDestroy();
         for (TestSubscriber sub : new TestSubscriber[]{sub1, sub2}) {
@@ -770,8 +770,8 @@ public class RxPermissionsTest {
 
         sub1 = new TestSubscriber<>();
         sub2 = new TestSubscriber<>();
-        trigger.compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub1);
-        trigger.compose(RxPermissions.ensureEach(mCtx, permission)).subscribe(sub2);
+        trigger.compose(mRxPermissions.ensureEach(permission)).subscribe(sub1);
+        trigger.compose(mRxPermissions.ensureEach(permission)).subscribe(sub2);
         mRxPermissions.onRequestPermissionsResult(0, new String[]{permission}, result);
 
         verify(mRxPermissions).startShadowActivity(any(String[].class));

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -19,17 +19,19 @@ public class MainActivity extends AppCompatActivity {
 
     private Camera mCamera;
     private SurfaceView mSurfaceView;
+    private RxPermissions mRxPermissions;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        RxPermissions.getInstance(this).setLogging(true);
+        mRxPermissions = RxPermissions.getInstance(this);
+        mRxPermissions.setLogging(true);
 
         setContentView(R.layout.act_main);
         mSurfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 
         RxView.clicks(findViewById(R.id.enableCamera))
-                .compose(RxPermissions.ensure(this, Manifest.permission.CAMERA))
+                .compose(mRxPermissions.ensure(Manifest.permission.CAMERA))
                 .subscribe(granted -> {
                             Log.i(TAG, " TRIGGER Received result " + granted);
                             if (granted) {

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -33,34 +33,49 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.act_main);
         mSurfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 
+        Observable.just(null)
+                .compose(RxPermissions.ensure(this, Manifest.permission.CAMERA))
+                .subscribe(granted -> {
+                    Log.i(TAG, "Received result " + granted);
+                    if (granted) {
+                        Toast.makeText(MainActivity.this,
+                                "Permission granted, enable the camera",
+                                Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(MainActivity.this,
+                                "Permission denied, can't enable the camera",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+
         // If the permission request is triggered by a particular event
         // (a click for instance) we need to pass that information threw
         // an Observable.
         // com.jakewharton.rxbinding.view.RxView does exactly what we need.
         Observable<Object> trigger = RxView.clicks(findViewById(R.id.enableCamera));
 
-        mRxPermissions
-                .request(trigger, Manifest.permission.CAMERA)
-                .subscribe(granted -> {
-                            Log.i(TAG, "Received result " + granted);
-                            if (granted) {
-                                releaseCamera();
-                                mCamera = Camera.open(0);
-                                try {
-                                    mCamera.setPreviewDisplay(mSurfaceView.getHolder());
-                                    mCamera.startPreview();
-                                } catch (IOException e) {
-                                    Log.e(TAG, "Error while trying to display the camera preview", e);
-                                }
-                            } else {
-                                Toast.makeText(MainActivity.this,
-                                        "Permission denied, can't enable the camera",
-                                        Toast.LENGTH_SHORT).show();
-                            }
-                        },
-                        t -> Log.e(TAG, "onError", t),
-                        () -> Log.i(TAG, "OnComplete")
-                );
+//        trigger
+//                .compose(RxPermissions.ensure(this, Manifest.permission.CAMERA))
+//                .subscribe(granted -> {
+//                            Log.i(TAG, " TRIGGER Received result " + granted);
+//                            if (granted) {
+//                                releaseCamera();
+//                                mCamera = Camera.open(0);
+//                                try {
+//                                    mCamera.setPreviewDisplay(mSurfaceView.getHolder());
+//                                    mCamera.startPreview();
+//                                } catch (IOException e) {
+//                                    Log.e(TAG, "Error while trying to display the camera preview", e);
+//                                }
+//                            } else {
+//                                Toast.makeText(MainActivity.this,
+//                                        "Permission denied, can't enable the camera",
+//                                        Toast.LENGTH_SHORT).show();
+//                            }
+//                        },
+//                        t -> Log.e(TAG, "onError", t),
+//                        () -> Log.i(TAG, "OnComplete")
+//                );
     }
 
     @Override

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -13,69 +13,43 @@ import com.tbruyelle.rxpermissions.RxPermissions;
 
 import java.io.IOException;
 
-import rx.Observable;
-
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "RxPermissionsSample";
 
-    private RxPermissions mRxPermissions;
     private Camera mCamera;
     private SurfaceView mSurfaceView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        mRxPermissions = RxPermissions.getInstance(this);
-        mRxPermissions.setLogging(true);
+        RxPermissions.getInstance(this).setLogging(true);
 
         setContentView(R.layout.act_main);
         mSurfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 
-        Observable.just(null)
+        RxView.clicks(findViewById(R.id.enableCamera))
                 .compose(RxPermissions.ensure(this, Manifest.permission.CAMERA))
                 .subscribe(granted -> {
-                    Log.i(TAG, "Received result " + granted);
-                    if (granted) {
-                        Toast.makeText(MainActivity.this,
-                                "Permission granted, enable the camera",
-                                Toast.LENGTH_SHORT).show();
-                    } else {
-                        Toast.makeText(MainActivity.this,
-                                "Permission denied, can't enable the camera",
-                                Toast.LENGTH_SHORT).show();
-                    }
-                });
-
-        // If the permission request is triggered by a particular event
-        // (a click for instance) we need to pass that information threw
-        // an Observable.
-        // com.jakewharton.rxbinding.view.RxView does exactly what we need.
-        Observable<Object> trigger = RxView.clicks(findViewById(R.id.enableCamera));
-
-//        trigger
-//                .compose(RxPermissions.ensure(this, Manifest.permission.CAMERA))
-//                .subscribe(granted -> {
-//                            Log.i(TAG, " TRIGGER Received result " + granted);
-//                            if (granted) {
-//                                releaseCamera();
-//                                mCamera = Camera.open(0);
-//                                try {
-//                                    mCamera.setPreviewDisplay(mSurfaceView.getHolder());
-//                                    mCamera.startPreview();
-//                                } catch (IOException e) {
-//                                    Log.e(TAG, "Error while trying to display the camera preview", e);
-//                                }
-//                            } else {
-//                                Toast.makeText(MainActivity.this,
-//                                        "Permission denied, can't enable the camera",
-//                                        Toast.LENGTH_SHORT).show();
-//                            }
-//                        },
-//                        t -> Log.e(TAG, "onError", t),
-//                        () -> Log.i(TAG, "OnComplete")
-//                );
+                            Log.i(TAG, " TRIGGER Received result " + granted);
+                            if (granted) {
+                                releaseCamera();
+                                mCamera = Camera.open(0);
+                                try {
+                                    mCamera.setPreviewDisplay(mSurfaceView.getHolder());
+                                    mCamera.startPreview();
+                                } catch (IOException e) {
+                                    Log.e(TAG, "Error while trying to display the camera preview", e);
+                                }
+                            } else {
+                                Toast.makeText(MainActivity.this,
+                                        "Permission denied, can't enable the camera",
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        },
+                        t -> Log.e(TAG, "onError", t),
+                        () -> Log.i(TAG, "OnComplete")
+                );
     }
 
     @Override

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -31,6 +31,7 @@ public class MainActivity extends AppCompatActivity {
         surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 
         RxView.clicks(findViewById(R.id.enableCamera))
+                // Ask for permissions when button is clicked
                 .compose(rxPermissions.ensure(Manifest.permission.CAMERA))
                 .subscribe(granted -> {
                             Log.i(TAG, " TRIGGER Received result " + granted);

--- a/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions/sample/MainActivity.java
@@ -17,29 +17,29 @@ public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "RxPermissionsSample";
 
-    private Camera mCamera;
-    private SurfaceView mSurfaceView;
-    private RxPermissions mRxPermissions;
+    private Camera camera;
+    private SurfaceView surfaceView;
+    private RxPermissions rxPermissions;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mRxPermissions = RxPermissions.getInstance(this);
-        mRxPermissions.setLogging(true);
+        rxPermissions = RxPermissions.getInstance(this);
+        rxPermissions.setLogging(true);
 
         setContentView(R.layout.act_main);
-        mSurfaceView = (SurfaceView) findViewById(R.id.surfaceView);
+        surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
 
         RxView.clicks(findViewById(R.id.enableCamera))
-                .compose(mRxPermissions.ensure(Manifest.permission.CAMERA))
+                .compose(rxPermissions.ensure(Manifest.permission.CAMERA))
                 .subscribe(granted -> {
                             Log.i(TAG, " TRIGGER Received result " + granted);
                             if (granted) {
                                 releaseCamera();
-                                mCamera = Camera.open(0);
+                                camera = Camera.open(0);
                                 try {
-                                    mCamera.setPreviewDisplay(mSurfaceView.getHolder());
-                                    mCamera.startPreview();
+                                    camera.setPreviewDisplay(surfaceView.getHolder());
+                                    camera.startPreview();
                                 } catch (IOException e) {
                                     Log.e(TAG, "Error while trying to display the camera preview", e);
                                 }
@@ -61,9 +61,9 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void releaseCamera() {
-        if (mCamera != null) {
-            mCamera.release();
-            mCamera = null;
+        if (camera != null) {
+            camera.release();
+            camera = null;
         }
     }
 }


### PR DESCRIPTION
Thanks to @xingrz and #36, I want to refactor the whole library usage.

Why ? Because I always disliked the need of passing a `trigger` to the parameter when the permission request is triggered by a button. The need for this architecture is because the `RxPermissions.request` must be invoked during initialization phase of the `Activity/Fragment/View`, to handle configuration changes.

But if we replace *observable* methods like `request` by *composable* methods, we can deal with that need in a more rx-compliant way.

With *composable* method we can ask a permission like that : 
```java
 RxView.clicks(findViewById(R.id.enableCamera))
                .compose(rxPermissions.ensure(Manifest.permission.CAMERA))
                .subscribe()
```

Note: the code still needs to be during initialization phase, but this is where we generally set click listeners, so it's ok.

So  `request/requestEach` methods are replaced by `ensure/ensureEach`.

WDYT ? 

(@patloew  your PR #37 is merged in that PR).

