### PR TITLE
https://github.com/tbruyelle/RxPermissions/issues/46 crash fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }

--- a/lib/src/main/java/com/tbruyelle/rxpermissions/ShadowActivity.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/ShadowActivity.java
@@ -5,15 +5,29 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Process;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class ShadowActivity extends Activity {
+    private static final String KEY_ORIGINAL_PID = "key_original_pid";
+
+    private int mOriginalProcessId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (savedInstanceState == null) {
             handleIntent(getIntent());
+
+            mOriginalProcessId = Process.myPid();
+        } else {
+            mOriginalProcessId = savedInstanceState.getInt(KEY_ORIGINAL_PID, mOriginalProcessId);
+
+            boolean restoredInAnotherProcess = mOriginalProcessId != Process.myPid();
+
+            if(restoredInAnotherProcess) {
+                finish();
+            }
         }
     }
 
@@ -31,5 +45,12 @@ public class ShadowActivity extends Activity {
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         RxPermissions.getInstance(this).onRequestPermissionsResult(requestCode, permissions, grantResults);
         finish();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putInt(KEY_ORIGINAL_PID, mOriginalProcessId);
     }
 }


### PR DESCRIPTION
Fixed crash that happens in situation described [here](https://github.com/tbruyelle/RxPermissions/issues/46).

These changes do not affect other situations when activity is recreated (display rotation, other config changes). 

I was unable to find solution, that would pass permission request results to the caller in this case. This part of issue still needs to be fixed.