### PR TITLE
If app was closed by system, fail silently instead of crashing

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions/RxPermissions.java
@@ -282,8 +282,11 @@ public class RxPermissions {
             // Find the corresponding subject
             PublishSubject<Permission> subject = mSubjects.get(permissions[i]);
             if (subject == null) {
-                // No subject found
-                throw new IllegalStateException("RxPermissions.onRequestPermissionsResult invoked but didn't find the corresponding permission request.");
+                // No subject found - the app has been closed by the system
+                // There is no good Rx way to handle this
+                // Also, there is a high probability that the user doesn't care for the result anymore anyways
+                // [citation needed]
+                return;
             }
             mSubjects.remove(permissions[i]);
             boolean granted = grantResults[i] == PackageManager.PERMISSION_GRANTED;


### PR DESCRIPTION
A temporary workaround for issue https://github.com/tbruyelle/RxPermissions/issues/46
In cases where the crash would otherwise happen, now nothing will happen (no failure, no success, no completion, nothing).
Similar to PR https://github.com/tbruyelle/RxPermissions/pull/53 but simpler and very slightly different.

Even though it's not a "proper fix", I've made this change for use in our production app until a real fix is available. I'm throwing it out there in case it might be useful for someone else as well.

You can use [jitpack.io](https://jitpack.io/#toumeitou/RxPermissions/cf0091040f) to get this in your project. Warning: it can get outdated.

Feel free to close the PR if you feel it's not appropriate, @tbruyelle 
