### PR TITLE
Public access to Permission constructors

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/Permission.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/Permission.java
@@ -5,11 +5,11 @@ public class Permission {
     public final boolean granted;
     public final boolean shouldShowRequestPermissionRationale;
 
-    Permission(String name, boolean granted) {
+    public Permission(String name, boolean granted) {
         this(name, granted, false);
     }
 
-    Permission(String name, boolean granted, boolean shouldShowRequestPermissionRationale) {
+    public Permission(String name, boolean granted, boolean shouldShowRequestPermissionRationale) {
         this.name = name;
         this.granted = granted;
         this.shouldShowRequestPermissionRationale = shouldShowRequestPermissionRationale;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,4 +24,7 @@ dependencies {
     compile rootProject.ext.appCompat
     compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
     compile 'com.github.akarnokd:rxjava2-interop:0.8.0'
+
+    testCompile rootProject.ext.junit
+    testCompile rootProject.ext.mockito
 }

--- a/sample/src/test/java/com/tbruyelle/rxpermissions/sample/RxPermissionsSampleTest.java
+++ b/sample/src/test/java/com/tbruyelle/rxpermissions/sample/RxPermissionsSampleTest.java
@@ -1,0 +1,49 @@
+package com.tbruyelle.rxpermissions.sample;
+
+
+import android.Manifest;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.os.Build;
+
+import com.tbruyelle.rxpermissions2.Permission;
+import com.tbruyelle.rxpermissions2.RxPermissions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.reactivex.Observable;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Sample tests for {@link RxPermissions}.
+ */
+public class RxPermissionsSampleTest {
+
+    @Mock
+    private Activity activity;
+    @Mock
+    private RxPermissions rxPermissions;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    @TargetApi(Build.VERSION_CODES.M)
+    public void test_permission_denied_dont_ask_again() throws Exception {
+        // mocks
+        final String permissionString = Manifest.permission.READ_PHONE_STATE;
+        final boolean granted = false;
+        final boolean shouldShowRequestPermissionRationale = false;
+        final Permission permission = new Permission(permissionString, granted, shouldShowRequestPermissionRationale);
+        when(rxPermissions.requestEach(permissionString)).thenReturn(Observable.just(permission));
+        // test
+        rxPermissions.requestEach(permissionString).test().assertNoErrors().assertValue(permission);
+    }
+
+}


### PR DESCRIPTION
Allows public access to `Permission` class constructors for mocking and testing return values for certain methods. 

#133