### PR TITLE
Add check for permissions

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissions.java
@@ -17,11 +17,14 @@ package com.tbruyelle.rxpermissions2;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.FragmentManager;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import io.reactivex.Observable;
@@ -38,10 +41,14 @@ public class RxPermissions {
     static final String TAG = "RxPermissions";
     static final Object TRIGGER = new Object();
 
+    private static List<String> mRegisteredInManifestPermissions;
     RxPermissionsFragment mRxPermissionsFragment;
 
     public RxPermissions(@NonNull Activity activity) {
         mRxPermissionsFragment = getRxPermissionsFragment(activity);
+        if (mRegisteredInManifestPermissions == null) {
+            mRegisteredInManifestPermissions = getRegisteredInManifestPermissions(activity);
+        }
     }
 
     private RxPermissionsFragment getRxPermissionsFragment(Activity activity) {
@@ -57,6 +64,23 @@ public class RxPermissions {
             fragmentManager.executePendingTransactions();
         }
         return rxPermissionsFragment;
+    }
+
+    private List<String> getRegisteredInManifestPermissions(Activity activity) {
+        if (activity == null) {
+            return null;
+        }
+        List<String> list = new ArrayList<>();
+        try {
+            PackageInfo packageInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), PackageManager.GET_PERMISSIONS);
+            String[] permissions = packageInfo.requestedPermissions;
+            if (permissions != null) {
+                list.addAll(Arrays.asList(permissions));
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+        return list;
     }
 
     private RxPermissionsFragment findRxPermissionsFragment(Activity activity) {
@@ -174,9 +198,7 @@ public class RxPermissions {
     }
 
     Observable<Permission> request(final Observable<?> trigger, final String... permissions) {
-        if (permissions == null || permissions.length == 0) {
-            throw new IllegalArgumentException("RxPermissions.request/requestEach requires at least one input permission");
-        }
+        checkPermissions(permissions);
         return oneOf(trigger, pending(permissions))
                 .flatMap(new Function<Object, Observable<Permission>>() {
                     @Override
@@ -296,6 +318,17 @@ public class RxPermissions {
     @SuppressWarnings("WeakerAccess")
     public boolean isRevoked(String permission) {
         return isMarshmallow() && mRxPermissionsFragment.isRevoked(permission);
+    }
+
+    void checkPermissions(String... permissions) {
+        if (permissions == null || permissions.length == 0) {
+            throw new IllegalArgumentException("RxPermissions.request/requestEach requires at least one input permission");
+        }
+        for (String p : permissions) {
+            if (!mRegisteredInManifestPermissions.contains(p)) {
+                throw new IllegalStateException("the permission \"" + p + "\" is not registered in manifest.xml");
+            }
+        }
     }
 
     boolean isMarshmallow() {

--- a/lib/src/test/java/com/tbruyelle/rxpermissions2/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions2/RxPermissionsTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -67,6 +68,9 @@ public class RxPermissionsTest {
         doReturn(false).when(mRxPermissions).isGranted(anyString());
         // Default no revoked permissions
         doReturn(false).when(mRxPermissions).isRevoked(anyString());
+
+        doNothing().when(mRxPermissions).checkPermissions(anyString());
+        doNothing().when(mRxPermissions).checkPermissions(anyString(),anyString());
     }
 
     private Observable<Object> trigger() {


### PR DESCRIPTION
   when we request some permissions but forget to register them in Manifest.xml, app will not show permission dialog and rxpermissions will return false immediately, sometimes this can make us confused. so to avoid this case, rxpermissions should throw a certain exception if the permissions we request are not registered in Manifest.xml