### PR TITLE
Support fragment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: android
 android:
   components:
     - tools
-    - build-tools-25.0.2
-    - android-25
+    - build-tools-27.0.3
+    - android-27
     - extra-android-m2repository
 
 jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ allprojects {
 }
 
 dependencies {
-    implementation 'com.github.tbruyelle:rxpermissions:0.9.6'
+    implementation 'com.github.tbruyelle:rxpermissions:0.10.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,15 @@ This library allows the usage of RxJava with the new Android M permission model.
 To use this library your `minSdkVersion` must be >= 11.
 
 ```gradle
+allprojects {
+    repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+    }
+}
+
 dependencies {
-    implementation 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.5@aar'
+    implementation 'com.github.tbruyelle:rxpermissions:0.9.6'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
     supportLibraryVersion = '27.1.1'
     appCompat = "com.android.support:appcompat-v7:$supportLibraryVersion"
     supportAnnotations = "com.android.support:support-annotations:$supportLibraryVersion"
+    supportFragment = "com.android.support:support-fragment:$supportLibraryVersion"
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,34 +1,35 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
 }
 
-subprojects {
+allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
 
 ext {
     minSdkVersion = 11
-    compileSdkVersion = 25
+    compileSdkVersion = 27
     targetSdkVersion = compileSdkVersion
-    buildToolsVersion = '25.0.2'
 
-    rxJava = 'io.reactivex.rxjava2:rxjava:2.1.8'
-    supportLibraryVersion = '25.2.0'
+    rxJava = 'io.reactivex.rxjava2:rxjava:2.1.16'
+    supportLibraryVersion = '27.1.1'
     appCompat = "com.android.support:appcompat-v7:$supportLibraryVersion"
     supportAnnotations = "com.android.support:support-annotations:$supportLibraryVersion"
     junit = 'junit:junit:4.12'
     mockito = 'org.mockito:mockito-core:1.10.19'
 
-    robolectricVersion = '3.1.4'
+    robolectricVersion = '3.3.2'
     robolectric = "org.robolectric:robolectric:$robolectricVersion"
     robolectricShadowsSupport = "org.robolectric:shadows-support-v4:$robolectricVersion"
     // Workaround for https://github.com/robolectric/robolectric/issues/1932

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 03 17:05:06 SGT 2017
+#Thu Jun 28 09:30:08 CDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,15 +1,12 @@
 apply plugin: 'com.android.library'
+apply from: 'jitpack.gradle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 12
-        version = rootProject.ext.libraryVersion
-        group = rootProject.ext.publishedGroupId + rootProject.ext.artifact
     }
     buildTypes {
         release {
@@ -28,15 +25,16 @@ android {
 }
 
 dependencies {
-    compile rootProject.ext.rxJava
-    compile rootProject.ext.supportAnnotations
+    implementation rootProject.ext.rxJava
+    implementation rootProject.ext.supportAnnotations
 
-    testCompile rootProject.ext.junit
-    testCompile rootProject.ext.mockito
-    testCompile rootProject.ext.robolectric
-    testCompile rootProject.ext.robolectricShadowsSupport
-    testCompile rootProject.ext.khronosOpenGLApi
+    testImplementation rootProject.ext.junit
+    testImplementation rootProject.ext.mockito
+    testImplementation rootProject.ext.robolectric
+    testImplementation rootProject.ext.robolectricShadowsSupport
+    testImplementation rootProject.ext.khronosOpenGLApi
 }
 
-apply from: 'install.gradle'
-apply from: 'bintray.gradle'
+// Commented to use JitPack instead of bintray
+//apply from: 'install.gradle'
+//apply from: 'bintray.gradle'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -27,6 +27,7 @@ android {
 dependencies {
     implementation rootProject.ext.rxJava
     implementation rootProject.ext.supportAnnotations
+    implementation rootProject.ext.supportFragment
 
     testImplementation rootProject.ext.junit
     testImplementation rootProject.ext.mockito

--- a/lib/jitpack.gradle
+++ b/lib/jitpack.gradle
@@ -1,0 +1,3 @@
+apply plugin: 'com.github.dcendents.android-maven'
+
+group = 'com.github.tbruyelle'

--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissions.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissions.java
@@ -16,9 +16,10 @@ package com.tbruyelle.rxpermissions2;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.app.FragmentManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 
 import java.util.ArrayList;
@@ -27,9 +28,6 @@ import java.util.List;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.ObservableTransformer;
-import io.reactivex.Single;
-import io.reactivex.SingleSource;
-import io.reactivex.SingleTransformer;
 import io.reactivex.functions.Function;
 import io.reactivex.subjects.PublishSubject;
 
@@ -40,16 +38,16 @@ public class RxPermissions {
 
     RxPermissionsFragment mRxPermissionsFragment;
 
-    public RxPermissions(@NonNull Activity activity) {
+    public RxPermissions(@NonNull FragmentActivity activity) {
         mRxPermissionsFragment = getRxPermissionsFragment(activity);
     }
 
-    private RxPermissionsFragment getRxPermissionsFragment(Activity activity) {
+    private RxPermissionsFragment getRxPermissionsFragment(@NonNull FragmentActivity activity) {
         RxPermissionsFragment rxPermissionsFragment = findRxPermissionsFragment(activity);
         boolean isNewInstance = rxPermissionsFragment == null;
         if (isNewInstance) {
             rxPermissionsFragment = new RxPermissionsFragment();
-            FragmentManager fragmentManager = activity.getFragmentManager();
+            FragmentManager fragmentManager = activity.getSupportFragmentManager();
             fragmentManager
                     .beginTransaction()
                     .add(rxPermissionsFragment, TAG)
@@ -59,8 +57,8 @@ public class RxPermissions {
         return rxPermissionsFragment;
     }
 
-    private RxPermissionsFragment findRxPermissionsFragment(Activity activity) {
-        return (RxPermissionsFragment) activity.getFragmentManager().findFragmentByTag(TAG);
+    private RxPermissionsFragment findRxPermissionsFragment(@NonNull FragmentActivity activity) {
+        return (RxPermissionsFragment) activity.getSupportFragmentManager().findFragmentByTag(TAG);
     }
 
     public void setLogging(boolean logging) {
@@ -84,7 +82,7 @@ public class RxPermissions {
                         .buffer(permissions.length)
                         .flatMap(new Function<List<Permission>, ObservableSource<Boolean>>() {
                             @Override
-                            public ObservableSource<Boolean> apply(List<Permission> permissions) throws Exception {
+                            public ObservableSource<Boolean> apply(List<Permission> permissions) {
                                 if (permissions.isEmpty()) {
                                     // Occurs during orientation change, when the subject receives onComplete.
                                     // In that case we don't want to propagate that empty list to the
@@ -136,7 +134,7 @@ public class RxPermissions {
                         .buffer(permissions.length)
                         .flatMap(new Function<List<Permission>, ObservableSource<Permission>>() {
                             @Override
-                            public ObservableSource<Permission> apply(List<Permission> permissions) throws Exception {
+                            public ObservableSource<Permission> apply(List<Permission> permissions) {
                                 if (permissions.isEmpty()) {
                                     return Observable.empty();
                                 }
@@ -169,18 +167,18 @@ public class RxPermissions {
      * Request permissions immediately, <b>must be invoked during initialization phase
      * of your application</b>.
      */
-    public Observable<Permission> requestEachCombined(final String... permissions){
+    public Observable<Permission> requestEachCombined(final String... permissions) {
         return Observable.just(TRIGGER).compose(ensureEachCombined(permissions));
     }
 
-    Observable<Permission> request(final Observable<?> trigger, final String... permissions) {
+    private Observable<Permission> request(final Observable<?> trigger, final String... permissions) {
         if (permissions == null || permissions.length == 0) {
             throw new IllegalArgumentException("RxPermissions.request/requestEach requires at least one input permission");
         }
         return oneOf(trigger, pending(permissions))
                 .flatMap(new Function<Object, Observable<Permission>>() {
                     @Override
-                    public Observable<Permission> apply(Object o) throws Exception {
+                    public Observable<Permission> apply(Object o) {
                         return requestImplementation(permissions);
                     }
                 });
@@ -203,7 +201,7 @@ public class RxPermissions {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    Observable<Permission> requestImplementation(final String... permissions) {
+    private Observable<Permission> requestImplementation(final String... permissions) {
         List<Observable<Permission>> list = new ArrayList<>(permissions.length);
         List<String> unrequestedPermissions = new ArrayList<>();
 

--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissionsFragment.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissionsFragment.java
@@ -1,15 +1,18 @@
 package com.tbruyelle.rxpermissions2;
 
 import android.annotation.TargetApi;
-import android.app.Fragment;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
 import android.util.Log;
-import io.reactivex.subjects.PublishSubject;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import io.reactivex.subjects.PublishSubject;
 
 public class RxPermissionsFragment extends Fragment {
 
@@ -68,12 +71,20 @@ public class RxPermissionsFragment extends Fragment {
 
     @TargetApi(Build.VERSION_CODES.M)
     boolean isGranted(String permission) {
-        return getActivity().checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED;
+        final FragmentActivity fragmentActivity = getActivity();
+        if (fragmentActivity == null) {
+            throw new IllegalStateException("This fragment must be attached to an activity.");
+        }
+        return fragmentActivity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED;
     }
 
     @TargetApi(Build.VERSION_CODES.M)
     boolean isRevoked(String permission) {
-        return getActivity().getPackageManager().isPermissionRevokedByPolicy(permission, getActivity().getPackageName());
+        final FragmentActivity fragmentActivity = getActivity();
+        if (fragmentActivity == null) {
+            throw new IllegalStateException("This fragment must be attached to an activity.");
+        }
+        return fragmentActivity.getPackageManager().isPermissionRevokedByPolicy(permission, getActivity().getPackageName());
     }
 
     public void setLogging(boolean logging) {
@@ -88,8 +99,8 @@ public class RxPermissionsFragment extends Fragment {
         return mSubjects.containsKey(permission);
     }
 
-    public PublishSubject<Permission> setSubjectForPermission(@NonNull String permission, @NonNull PublishSubject<Permission> subject) {
-        return mSubjects.put(permission, subject);
+    public void setSubjectForPermission(@NonNull String permission, @NonNull PublishSubject<Permission> subject) {
+        mSubjects.put(permission, subject);
     }
 
     void log(String message) {

--- a/lib/src/test/java/com/tbruyelle/rxpermissions2/RxPermissionsTest.java
+++ b/lib/src/test/java/com/tbruyelle/rxpermissions2/RxPermissionsTest.java
@@ -19,6 +19,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.v4.app.FragmentActivity;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +28,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
-import org.robolectric.util.ActivityController;
 
 import io.reactivex.Observable;
 import io.reactivex.observers.TestObserver;
@@ -50,13 +51,13 @@ import static org.mockito.Mockito.when;
 @Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.M)
 public class RxPermissionsTest {
 
-    private Activity mActivity;
+    private FragmentActivity mActivity;
 
     private RxPermissions mRxPermissions;
 
     @Before
     public void setup() {
-        ActivityController<Activity> activityController = Robolectric.buildActivity(Activity.class);
+        ActivityController<FragmentActivity> activityController = Robolectric.buildActivity(FragmentActivity.class);
         mActivity = spy(activityController.setup().get());
         mRxPermissions = spy(new RxPermissions(mActivity));
         mRxPermissions.mRxPermissionsFragment = spy(mRxPermissions.mRxPermissionsFragment);
@@ -521,7 +522,7 @@ public class RxPermissionsTest {
         when(activity.shouldShowRequestPermissionRationale(anyString())).thenReturn(true);
 
         TestObserver<Boolean> sub = new TestObserver<>();
-        mRxPermissions.shouldShowRequestPermissionRationale(activity, new String[]{"p1", "p2"})
+        mRxPermissions.shouldShowRequestPermissionRationale(activity, "p1", "p2")
                 .subscribe(sub);
 
         sub.assertComplete();
@@ -537,7 +538,7 @@ public class RxPermissionsTest {
         when(activity.shouldShowRequestPermissionRationale("p1")).thenReturn(true);
 
         TestObserver<Boolean> sub = new TestObserver<>();
-        mRxPermissions.shouldShowRequestPermissionRationale(activity, new String[]{"p1", "p2"})
+        mRxPermissions.shouldShowRequestPermissionRationale(activity, "p1", "p2")
                 .subscribe(sub);
 
         sub.assertComplete();
@@ -552,7 +553,7 @@ public class RxPermissionsTest {
         Activity activity = mock(Activity.class);
 
         TestObserver<Boolean> sub = new TestObserver<>();
-        mRxPermissions.shouldShowRequestPermissionRationale(activity, new String[]{"p1", "p2"})
+        mRxPermissions.shouldShowRequestPermissionRationale(activity, "p1", "p2")
                 .subscribe(sub);
 
         sub.assertComplete();
@@ -569,7 +570,7 @@ public class RxPermissionsTest {
         when(activity.shouldShowRequestPermissionRationale("p2")).thenReturn(true);
 
         TestObserver<Boolean> sub = new TestObserver<>();
-        mRxPermissions.shouldShowRequestPermissionRationale(activity, new String[]{"p1", "p2"})
+        mRxPermissions.shouldShowRequestPermissionRationale(activity, "p1", "p2")
                 .subscribe(sub);
 
         sub.assertComplete();
@@ -585,7 +586,7 @@ public class RxPermissionsTest {
         when(mRxPermissions.isGranted("p2")).thenReturn(true);
 
         TestObserver<Boolean> sub = new TestObserver<>();
-        mRxPermissions.shouldShowRequestPermissionRationale(activity, new String[]{"p1", "p2"})
+        mRxPermissions.shouldShowRequestPermissionRationale(activity, "p1", "p2")
                 .subscribe(sub);
 
         sub.assertComplete();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.tbruyelle.rxpermissions.sample"
@@ -19,12 +18,11 @@ android {
 }
 
 dependencies {
-    compile project(':rxpermissions')
+    implementation project(':rxpermissions')
 
-    compile rootProject.ext.appCompat
-    compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
-    compile 'com.github.akarnokd:rxjava2-interop:0.8.0'
+    implementation rootProject.ext.appCompat
+    implementation 'com.jakewharton.rxbinding2:rxbinding:2.1.1'
 
-    testCompile rootProject.ext.junit
-    testCompile rootProject.ext.mockito
+    testImplementation rootProject.ext.junit
+    testImplementation rootProject.ext.mockito
 }

--- a/sample/src/main/java/com/tbruyelle/rxpermissions2/sample/MainActivity.java
+++ b/sample/src/main/java/com/tbruyelle/rxpermissions2/sample/MainActivity.java
@@ -7,14 +7,16 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.SurfaceView;
 import android.widget.Toast;
-import com.jakewharton.rxbinding.view.RxView;
+
+import com.jakewharton.rxbinding2.view.RxView;
 import com.tbruyelle.rxpermissions2.Permission;
 import com.tbruyelle.rxpermissions2.RxPermissions;
-import hu.akarnokd.rxjava.interop.RxJavaInterop;
+
+import java.io.IOException;
+
+import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Consumer;
-import java.io.IOException;
-import rx.functions.Func1;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -22,6 +24,7 @@ public class MainActivity extends AppCompatActivity {
 
     private Camera camera;
     private SurfaceView surfaceView;
+    private Disposable disposable;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,58 +33,58 @@ public class MainActivity extends AppCompatActivity {
         rxPermissions.setLogging(true);
 
         setContentView(R.layout.act_main);
-        surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
+        surfaceView = findViewById(R.id.surfaceView);
 
-        RxJavaInterop.toV2Observable(
-              RxView.clicks(findViewById(R.id.enableCamera))
-                    .map(new Func1<Void, Object>() {
-                        @Override
-                        public Object call(final Void aVoid) {
-                            return new Object();
-                        }
-                    })
-        )
-              // Ask for permissions when button is clicked
-              .compose(rxPermissions.ensureEach(permission.CAMERA))
-              .subscribe(new Consumer<Permission>() {
-                             @Override
-                             public void accept(Permission permission) {
-                                 Log.i(TAG, "Permission result " + permission);
-                                 if (permission.granted) {
-                                     releaseCamera();
-                                     camera = Camera.open(0);
-                                     try {
-                                         camera.setPreviewDisplay(surfaceView.getHolder());
-                                         camera.startPreview();
-                                     } catch (IOException e) {
-                                         Log.e(TAG, "Error while trying to display the camera preview", e);
-                                     }
-                                 } else if (permission.shouldShowRequestPermissionRationale) {
-                                     // Denied permission without ask never again
-                                     Toast.makeText(MainActivity.this,
-                                           "Denied permission without ask never again",
-                                           Toast.LENGTH_SHORT).show();
-                                 } else {
-                                     // Denied permission with ask never again
-                                     // Need to go to the settings
-                                     Toast.makeText(MainActivity.this,
-                                           "Permission denied, can't enable the camera",
-                                           Toast.LENGTH_SHORT).show();
-                                 }
-                             }
-                         },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable t) {
-                            Log.e(TAG, "onError", t);
-                        }
-                    },
-                    new Action() {
-                        @Override
-                        public void run() {
-                            Log.i(TAG, "OnComplete");
-                        }
-                    });
+        disposable = RxView.clicks(findViewById(R.id.enableCamera))
+                // Ask for permissions when button is clicked
+                .compose(rxPermissions.ensureEach(permission.CAMERA))
+                .subscribe(new Consumer<Permission>() {
+                               @Override
+                               public void accept(Permission permission) {
+                                   Log.i(TAG, "Permission result " + permission);
+                                   if (permission.granted) {
+                                       releaseCamera();
+                                       camera = Camera.open(0);
+                                       try {
+                                           camera.setPreviewDisplay(surfaceView.getHolder());
+                                           camera.startPreview();
+                                       } catch (IOException e) {
+                                           Log.e(TAG, "Error while trying to display the camera preview", e);
+                                       }
+                                   } else if (permission.shouldShowRequestPermissionRationale) {
+                                       // Denied permission without ask never again
+                                       Toast.makeText(MainActivity.this,
+                                               "Denied permission without ask never again",
+                                               Toast.LENGTH_SHORT).show();
+                                   } else {
+                                       // Denied permission with ask never again
+                                       // Need to go to the settings
+                                       Toast.makeText(MainActivity.this,
+                                               "Permission denied, can't enable the camera",
+                                               Toast.LENGTH_SHORT).show();
+                                   }
+                               }
+                           },
+                        new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable t) {
+                                Log.e(TAG, "onError", t);
+                            }
+                        },
+                        new Action() {
+                            @Override
+                            public void run() {
+                                Log.i(TAG, "OnComplete");
+                            }
+                        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (disposable != null && !disposable.isDisposed()) {
+            disposable.dispose();
+        }
+        super.onDestroy();
     }
 
     @Override
@@ -96,4 +99,5 @@ public class MainActivity extends AppCompatActivity {
             camera = null;
         }
     }
+
 }


### PR DESCRIPTION
This PR fixes #128 since `android.app.Fragment` was deprecated.

@tbruyelle This must be reviewed and merged after #231 . We could do a new release just after these two PRs I guess.