### PR TITLE
Add 'Issue template' and 'Bug report template'

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: 'Create a bug report. '
+title: Bug
+labels: ''
+assignees: ''
+
+---
+
+### Prerequisites
+
+* [] Put an X between the brackets on this line if you have done all of the following:
+    * Read carefully README: https://github.com/tbruyelle/RxPermissions#rxpermissions
+    * Checked that your issue isn't already filed: https://github.com/tbruyelle/RxPermissions/issues
+
+### Issue description
+[A clear and concise description of what the bug is.]
+
+### Actual behavior
+[A clear and concise description of what actually happened.]
+
+### Expected behavior
+[A clear and concise description of what you expected to happen.]
+
+### Steps To Reproduce
+Steps to reproduce the behavior:
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+### RxPermission usage code **(extremely Required)**
+Give a comprehensive example of how exactly RxPermission is used (Use [gists](https://gist.github.com/) or style code with styling markdown). 
+Provide all info from the beginning that includes:
+- How and where RxPermission was instantiated. 
+- In what lifecycle method. Activity or fragment. Give info about screen view hierarchy if it really complicated and has many nested Fragments.
+- Some additional info or important context if needed. 
+
+### Lib Version
+Give info about what lib version do you use
+
+**Screenshots**
+Add screenshots to help explain your problem only If it will be handy for your use case.
+If issued only with particular device provide device info 
+ - Device: [e.g. Nexus 5]
+ - OS version: [Android 5.1]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add 'bug report' and 'feature' templates. From now users who want to open a new issue
will be asked to fill down some template in order to give a comprehensive information
about some bug or another code defect.
Also, the user will be asked first to chose one of 2 options
 - create a Bug report
 - create a Feature request

