### PR TITLE
Fix permission request subjects being not complete

### DIFF
--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/CancelPermissionRequestException.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/CancelPermissionRequestException.java
@@ -1,0 +1,8 @@
+package com.tbruyelle.rxpermissions2;
+
+public class CancelPermissionRequestException extends Exception {
+
+    CancelPermissionRequestException(String message) {
+        super(message);
+    }
+}

--- a/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissionsFragment.java
+++ b/lib/src/main/java/com/tbruyelle/rxpermissions2/RxPermissionsFragment.java
@@ -10,6 +10,7 @@ import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import io.reactivex.subjects.PublishSubject;
@@ -101,6 +102,16 @@ public class RxPermissionsFragment extends Fragment {
 
     public void setSubjectForPermission(@NonNull String permission, @NonNull PublishSubject<Permission> subject) {
         mSubjects.put(permission, subject);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        String message = "These permission requests cleared with onStop called";
+        for (PublishSubject<Permission> permissionPublishSubject : mSubjects.values()) {
+            permissionPublishSubject.onError(new CancelPermissionRequestException(message));
+        }
+        mSubjects.clear();
     }
 
     void log(String message) {


### PR DESCRIPTION
- Fix issue, when permission request is started, but then app put to background and resumed
  - Expected:
    - Request could be started again
  - Existant:
    - Request cant be started, because, there is not finished requests in queue

- So now all requests could be finished with cancelation exception and requests cleared from list