### PR TITLE
Fixed Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ rxPermissions
         if (granted) { // Always true pre-M
            // I can control the camera now
         } else {
-           // Oups permission denied
+           // Oops permission denied
         }
     });
 ```


### PR DESCRIPTION
Fixed Typo Found In README.md file of RXPERMISSION Repo